### PR TITLE
讓sleep跟wake_up兩個可以使用傳入的時間參數

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -11,22 +11,40 @@ class UserController < ApplicationController
   end
 
   def sleep
-    sleep_params = params.permit(:id).to_h.with_indifferent_access
+    sleep_params = params.permit(:id, :record_id, :sleep_time).to_h.with_indifferent_access
     user_id = sleep_params[:id]
-    User.find(user_id).sleep_records.create(sleep: Time.zone.now)
+    record_id = sleep_params[:record_id]
+    time_at = trans_time_to_local(sleep_params[:sleep_time])
+    if record_id.nil?
+      User.find(user_id).sleep_records.create(sleep: time_at)
+    else
+      record = SleepRecord.find(record_id)
+      raise 'Wake_up earier than sleep' if (time_at > record.wake_up) && record.wake_up.present?
+
+      record.sleep = time_at
+      record.save!
+    end
     render(json: { success: true, error: nil })
   rescue StandardError => e
     render(json: { success: false, error: e.message })
   end
 
   def wake_up
-    wake_up_params = params.permit(:id, :record_id).to_h.with_indifferent_access
+    wake_up_params = params.permit(:id, :record_id, :wake_up_time).to_h.with_indifferent_access
     record_id = wake_up_params[:record_id]
+    time_at = trans_time_to_local(wake_up_params[:wake_up_time])
     record = SleepRecord.find(record_id)
-    record.wake_up = Time.zone.now
+    raise 'Wake_up earier than sleep' if (record.sleep > time_at) && record.sleep.present?
+
+    record.wake_up = time_at
     record.save!
     render(json: { success: true, error: nil })
   rescue StandardError => e
     render(json: { success: false, error: e.message })
+  end
+
+  def trans_time_to_local(time_param)
+    time_at = Time.zone.parse(time_string) unless time_param.nil?
+    time_at || Time.zone.now
   end
 end


### PR DESCRIPTION
原本預設的情境是需要sleep建立SleepRecord並記錄時間
wake_up透過record_id去紀錄已經紀錄過入睡的紀錄，這次紀錄起床。

新增時間參數讓使用者可能先按下入睡後拖延症玩手機，後來才入睡可以更改已建檔的紀錄。
或使用者不一定要紀錄當下，可能是紀錄過去的睡眠紀錄，因此改用時間參數增加擴充性。