### PR TITLE
修正n+1問題

### DIFF
--- a/app/models/sleep_record.rb
+++ b/app/models/sleep_record.rb
@@ -4,19 +4,6 @@ class SleepRecord < ApplicationRecord
   # callbacks
   before_save :calculate_duration, if: :check_time_start_and_end?
   # scope
-  scope :search_by_date,
-  (lambda do |sdate, edate|
-     sdate_time = sdate.beginning_of_day
-     edate_time = edate.end_of_day
-     where(
-       '(sleep between ? and ?) OR (wake_up between ? and ?)',
-       sdate_time,
-       edate_time,
-       sdate_time,
-       edate_time,
-     )
-   end
-  )
 
   private
 


### PR DESCRIPTION
在檢視追蹤中的先前一週睡眠紀錄，
原先的寫法會造成每次回傳個別追蹤中user的睡眠紀錄json都會重新Load一次SleepRecord
而且原先的睡眠durations並沒有設定到上一週的區間，
因此重新改寫修正上面問題，並移除SleepRecord Model中沒用到的scope